### PR TITLE
Don't require git tag to auth for docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 install:
   - ./travis-scripts/install.sh
 script:
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ -n "$TRAVIS_TAG" ]; then
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       $(aws ecr get-login);
     fi
   - ./travis-scripts/build_assets.sh


### PR DESCRIPTION
Will now authenticate to AWS Docker on any merge to master, so image
builds will run faster. `deploy.sh` still requires a tag for pushing.