### PR TITLE
Fix Travis post-upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 sudo: false  # http://docs.travis-ci.com/user/migrating-from-legacy/
 language: python
 cache: pip
+group: deprecated-2017Q3
 python:
   - 3.4.5
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 sudo: false  # http://docs.travis-ci.com/user/migrating-from-legacy/
 language: python
 cache: pip
-group: deprecated-2017Q3
+group: deprecated-2017Q2
 python:
   - 3.4.5
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 sudo: false  # http://docs.travis-ci.com/user/migrating-from-legacy/
 language: python
 cache: pip
-group: deprecated-2017Q2
 python:
   - 3.4.5
 services:

--- a/app/requirements/dev.txt
+++ b/app/requirements/dev.txt
@@ -10,7 +10,7 @@ factory-boy==2.8.1
 flake8==3.3.0
 flake8-blind-except==0.1.1
 flake8-debugger==1.4.0
-flake8-docstrings==1.0.3
+flake8-docstrings==1.1.0
 flake8-isort==2.1.3
 flake8-quotes==0.9.0
 isort==4.2.5

--- a/app/setup.cfg
+++ b/app/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
+ignore = D401
 max-line-length=80


### PR DESCRIPTION
It looks like Travis builds broke due to a infra upgrade by Travis. This is an attempt to resolve said issues.

UPDATE: While this may have been triggered by a Travis upgrade, this seems to have actually been a bug in `flake8-docstrings-1.0.3`. Updating the package has resolved the issue.